### PR TITLE
Fix for issue #190

### DIFF
--- a/src/theme/DocItem/Content/index.js
+++ b/src/theme/DocItem/Content/index.js
@@ -60,7 +60,6 @@ export default function DocItemContent({ children }) {
             </p>
             <input
               id="EMAIL"
-              autoFocus
               type="email"
               value={fields.EMAIL}
               onChange={handleFieldChange}


### PR DESCRIPTION
Removed autofocus attribute from newsletter form field to stop homepage jumping to bottom.

Resolves https://github.com/Green-Software-Foundation/learn/issues/190