### PR TITLE
Correct the definition of the acronym UNFCCC in glossary.md

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -113,7 +113,7 @@ sidebar_position: 9
    </td>
   </tr>
   <tr>
-   <td><strong>United Nations Framework Convention on Climate</strong>
+   <td><strong>United Nations Framework Convention on Climate Change</strong>
    </td>
    <td><strong>UNFCCC</strong>
    </td>


### PR DESCRIPTION
Correct the definition of the acronym UNFCCC (otherwise, there is no correspondence with the 3rd C)