### PR TITLE
Update climate-commitments.mdx

### DIFF
--- a/docs/climate-commitments.mdx
+++ b/docs/climate-commitments.mdx
@@ -254,7 +254,7 @@ Carbon aware computing helps organizations increase their CFE percentage.
       ],
     },
     {
-      question: "What is responsible for setting the standard for net zero?",
+      question: "Who is responsible for setting the standard for net zero?",
       answers: [
         {
           text: "SBTi",


### PR DESCRIPTION
What is responsible for setting the standard for net zero? should be Who is responsible for setting the standard for net zero? As in the context it's a standard set by Science Based Targets initiative,

@russelltrow  /  @franziska-warncke happy for you to rattle over, and merge it,

Cheers!